### PR TITLE
Only do main build and publish on 'Version Package' commits and pull  requests

### DIFF
--- a/.github/workflows/azure-static-web-apps-brave-sky-0982bfc10.yml
+++ b/.github/workflows/azure-static-web-apps-brave-sky-0982bfc10.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: (github.event_name == 'push' && startsWith(github.event.commits[0].message, 'Version Package')) || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:


### PR DESCRIPTION
This means we only build and publish the static web site demo when a new release is created via the changesets generated PR. Other commits on main won't rebuild the demo static site because a staging static site will be created for the Versioning PR which will be generated when a PR is merged to main.